### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0+38] - August 26, 2025
+
+* Automated dependency updates
+
+
 ## [4.0.0+37] - July 1, 2025
 
 * Automated dependency updates

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: "example"
 description: "Example app for the JsonDynamicWidget library"
 publish_to: "none"
-version: "1.0.0+24"
+version: "1.0.0+25"
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: "flutter"
   font_awesome_flutter_named: "^1.1.2+1"
-  json_dynamic_widget: "^10.0.1"
+  json_dynamic_widget: "^10.0.2"
   json_dynamic_widget_plugin_font_awesome:
     path: "../"
   logging: "^1.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: "json_dynamic_widget_plugin_font_awesome"
 description: "A plugin to the JSON Dynamic Widget to provide Font Awesome support to the widgets"
 homepage: "https://github.com/peiffer-innovations/json_dynamic_widget_plugin_font_awesome"
-version: "4.0.0+37"
+version: "4.0.0+38"
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
@@ -15,10 +15,10 @@ dependencies:
   child_builder: "^2.0.2"
   flutter:
     sdk: "flutter"
-  font_awesome_flutter: "^10.8.0"
+  font_awesome_flutter: "^10.10.0"
   font_awesome_flutter_named: "^1.1.2+1"
   json_class: "^3.0.1"
-  json_dynamic_widget: "^10.0.1"
+  json_dynamic_widget: "^10.0.2"
   json_theme: "^9.0.1+2"
   logging: "^1.3.0"
   meta: "^1.12.0"
@@ -28,7 +28,7 @@ false_secrets:
   - "example/web/index.html"
 
 dev_dependencies:
-  build_runner: "^2.5.4"
+  build_runner: "^2.7.0"
   flutter_lints: "^6.0.0"
   flutter_test:
     sdk: "flutter"


### PR DESCRIPTION
PR created automatically


dependencies:
  * `font_awesome_flutter`: 10.8.0 --> 10.10.0
  * `json_dynamic_widget`: 10.0.1 --> 10.0.2

dev_dependencies:
  * `build_runner`: 2.5.4 --> 2.7.0


Error!!!
```
Resolving dependencies...


Because json_dynamic_widget_codegen >=2.0.0+2 depends on build ^2.4.2 and build_runner >=2.7.0 depends on build 3.0.2, json_dynamic_widget_codegen >=2.0.0+2 is incompatible with build_runner >=2.7.0.
So, because json_dynamic_widget_plugin_font_awesome depends on both build_runner ^2.7.0 and json_dynamic_widget_codegen ^3.0.0, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on build_runner: flutter pub add dev:build_runner:^2.5.4
Failed to update packages.

```


dependencies:
  * `json_dynamic_widget`: 10.0.1 --> 10.0.2


Analysis Successful

